### PR TITLE
Add ability to change the "host" where the UI is hosted

### DIFF
--- a/src/fprime_visual/__main__.py
+++ b/src/fprime_visual/__main__.py
@@ -29,6 +29,12 @@ def parse_args():
         help="GUI theme [dark|dark-blue|light-seafoam]",
         required=False,
     )
+    parser.add_argument(
+	"--host",
+	default="127.0.0.1",
+	help="IP address to host fprime-visual",
+	required=False,
+    )
 
     args = parser.parse_args()
     return args
@@ -52,7 +58,7 @@ def main():
 
     app = construct_app(config)
 
-    app.run(port=args.gui_port)
+    app.run(host=args.host,port=args.gui_port)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Currently, the UI only hosts on localhost. However, when using remote servers for F Prime development, you may want to host the UI on the IP address of the remote node, so it is accessible everywhere.

The `--host` flag takes in an IP (ex `--host 100.100.4.100`). If none is specified, it will default to localhost.